### PR TITLE
Return message when graph API returns 304

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,26 @@ You can also make multiple calls at once using Facebook's batch API:
 end
 ```
 
+You can pass headers to Graph API calls via the `options` hash. For example, if
+you want to optimize graph api data fetching with <a
+href="https://developers.facebook.com/blog/post/627/">ETags</a>, you can make a
+graph call like this:
+
+```ruby
+etag_from_last_request = "\"123abc\""
+@graph.get_object("me", headers: { "If-None-Match" => etag_from_last_request })
+```
+
+If the ETag passed in the headers matches the current ETag, Koala will not
+return data for the endpoint. Instead, the response will look like:
+
+```ruby
+{
+  "message" => "Response not modified",
+  "response_code" => "304",
+}
+```
+
 You can pass a "post-processing" block to each of Koala's Graph API methods. This is handy for two reasons:
 
 1. You can modify the result returned by the Graph API method:

--- a/spec/cases/graph_api_spec.rb
+++ b/spec/cases/graph_api_spec.rb
@@ -26,6 +26,15 @@ describe 'Koala::Facebook::GraphAPIMethods' do
         expect(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(200, "", ""))
         expect(@api.get_object('koppel', args, &post_processing)["result"]).to eq(result)
       end
+
+      context "etag headers sent with response match data" do
+        it "returns a 304 and helpful response body" do
+          response_hash = { "message" => "Response not modified", "response_code" => "304" }
+          expect(Koala).to receive(:make_request).and_return(Koala::HTTPService::Response.new(304, "", ""))
+
+          expect(@api.get_object("koppel", {})).to eq(response_hash)
+        end
+      end
     end
 
     context '#get_picture' do


### PR DESCRIPTION
- If sending etags to graph API and etags match, response body will be nil
- Source: https://developers.facebook.com/docs/marketing-api/etags
